### PR TITLE
Refactor cryptocurrency price fetching to retrieve live market data f…

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,20 +1,23 @@
 import requests
 from flask import Flask, jsonify, render_template
 
+# Define a constant for the number of cryptocurrencies to fetch
+CRYPTO_COUNT = 100
+
 app = Flask(__name__)
 
 # Function to fetch live cryptocurrency prices
 def fetch_crypto_prices():
-    url = "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum,dogecoin&vs_currencies=usd"
+    url = f"https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page={CRYPTO_COUNT}&page=1&sparkline=false"
     response = requests.get(url)
     if response.status_code == 200:
-        return response.json()
+        data = response.json()
+        prices = {}
+        for coin in data:
+            prices[coin['name']] = coin['current_price']
+        return prices
     else:
-        return {
-            "Bitcoin": "Error fetching price",
-            "Ethereum": "Error fetching price",
-            "Dogecoin": "Error fetching price"
-        }
+        return {f"Crypto_{i+1}": "Error fetching price" for i in range(CRYPTO_COUNT)}
 
 @app.route('/')
 def home():


### PR DESCRIPTION
This pull request updates the cryptocurrency price fetching logic to support retrieving prices for the top 100 cryptocurrencies by market capitalization, rather than just three hardcoded coins. The implementation is now more dynamic and scalable, allowing for easier adjustments in the future.

**Enhancements to cryptocurrency price fetching:**

* Introduced a `CRYPTO_COUNT` constant to control how many cryptocurrencies are fetched, making the code more flexible.
* Updated the API endpoint and request logic in `fetch_crypto_prices()` to retrieve the top 100 cryptocurrencies by market cap, and refactored the response parsing to build a dictionary of coin names and their current prices.
* Improved error handling to return a dictionary with placeholder error messages for each expected cryptocurrency if the API request fails.…or multiple coins